### PR TITLE
Add bind mount for media directory

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     depends_on:
       - mongo
     restart: always
+    volumes:
+      - ./media:/app/media
     env_file: .env
     environment:
       MONGO_HOSTNAME: mongo


### PR DESCRIPTION
Reference #60 

Developers/users must include a media directory in the same directory as the compose script and this will get mounted to the container externally. Sweet decoupling of media and code.

Also, added the required documentation.